### PR TITLE
Removed call to next() in ensureAuthenticated

### DIFF
--- a/packages/oidc-middleware/src/oidcUtil.js
+++ b/packages/oidc-middleware/src/oidcUtil.js
@@ -71,7 +71,6 @@ oidcUtil.ensureAuthenticated = (context, options) => {
       ensureLoggedIn(options)(req, res, next);
     } else {
       res.sendStatus(401);
-      next();
     }
   };
 }


### PR DESCRIPTION
Calling next() after sendStatus(401) results in calling the next middleware which is not correct as the response is already sent to the client. The next() middleware if updates the headers results in 500 error 

**Stacktrace**
```
[Node] POST /api/test 500 23.812 ms - 12
[Node] _http_outgoing.js:503
[Node]     throw new errors.Error('ERR_HTTP_HEADERS_SENT', 'set');
[Node]     ^
[Node] 
[Node] Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
[Node]     at validateHeader (_http_outgoing.js:503:11)
[Node]     at ServerResponse.setHeader (_http_outgoing.js:510:3)
[Node]     at ServerResponse.header (/Users/ahmednasir/Documents/Workspace/bugreport/node_modules/express/lib/response.js:767:10)
[Node]     at ServerResponse.send (/Users/ahmednasir/Documents/Workspace/test/node_modules/express/lib/response.js:170:12)
[Node]     at done (/Users/ahmednasir/Documents/Workspace/test/node_modules/express/lib/response.js:1004:10)
[Node]     at /Users/ahmednasir/Documents/Workspace/test/node_modules/swig/lib/swig.js:565:9
[Node]     at /Users/ahmednasir/Documents/Workspace/test/node_modules/swig/lib/swig.js:690:9
[Node]     at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:532:3)
```

More info here
https://stackoverflow.com/a/38621009/604493